### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,6 +13,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: {} # Uses PROJECT_TOKEN; default GITHUB_TOKEN is not passed to add-to-project.
 
     steps:

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -5,10 +5,16 @@ on:
     types:
       - opened
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions: {} # Uses PROJECT_TOKEN; default GITHUB_TOKEN is not passed to add-to-project.
+
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write       # Required for reusable workflow to commit translation updates.
+      pull-requests: write # Required for reusable workflow to open/update pull requests.
     with:
       text_domain: 'wp-plugin-bluehost'
       i18n-script-location: 'npm'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,6 +19,7 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write       # Required for reusable workflow to commit translation updates.

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -22,6 +22,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {} # Computes outputs only; no checkout or GitHub API calls with GITHUB_TOKEN.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -32,6 +33,7 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
+    timeout-minutes: 90
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write       # Required for reusable workflow to publish coverage artifacts/commits.

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -15,12 +15,14 @@ on:
       - release/*
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Computes outputs only; no checkout or GitHub API calls with GITHUB_TOKEN.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -30,10 +32,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write       # Required for reusable workflow to publish coverage artifacts/commits.
+      pull-requests: write # Required for reusable workflow pull-request interactions.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -8,13 +8,15 @@ on:
         required: true
         default: ""
 
-permissions:
-  issues: write
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   create-milestone:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to create milestones via the GitHub REST API with GITHUB_TOKEN.
 
     steps:
       - name: Create Milestone

--- a/.github/workflows/create-milestone.yml
+++ b/.github/workflows/create-milestone.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   create-milestone:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       issues: write # Required to create milestones via the GitHub REST API with GITHUB_TOKEN.
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -13,6 +13,7 @@ jobs:
   delete:
     name: On Delete Release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: ${{ github.repository == 'newfold-labs/wp-plugin-hostgator' }}
     permissions: {} # Cloudflare purge uses repository secrets; GITHUB_TOKEN is unused.
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -14,6 +14,8 @@ jobs:
     name: On Delete Release
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'newfold-labs/wp-plugin-hostgator' }}
+    permissions: {} # Cloudflare purge uses repository secrets; GITHUB_TOKEN is unused.
+
     steps:
 
       - name: Clear cache for release API

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,7 @@ permissions: {}
 jobs:
   ESLint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository.
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -25,7 +25,8 @@ jobs:
   ESLint:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required to checkout the repository.
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-php:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository for PHPCS diffs.
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -23,6 +23,7 @@ jobs:
   lint-php:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository for PHPCS diffs.
 

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -10,9 +10,17 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-yml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository.
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -18,6 +18,7 @@ permissions: {}
 jobs:
   lint-yml:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read # Required to checkout the repository.
 

--- a/.github/workflows/newfold-prepare-release.yml
+++ b/.github/workflows/newfold-prepare-release.yml
@@ -32,6 +32,7 @@ jobs:
   # This runs the Newfold reusable-plugin-prep-release workflow for this plugin to prepare a release.
   prep-release:
     name: Prepare Release
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-plugin-prep-release.yml@main
     permissions:
       contents: write       # Required for reusable workflow to prepare release branches/commits.

--- a/.github/workflows/newfold-prepare-release.yml
+++ b/.github/workflows/newfold-prepare-release.yml
@@ -32,10 +32,10 @@ jobs:
   # This runs the Newfold reusable-plugin-prep-release workflow for this plugin to prepare a release.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-plugin-prep-release.yml@main
+    permissions:
+      contents: write       # Required for reusable workflow to prepare release branches/commits.
+      pull-requests: write # Required for reusable workflow pull-request operations.
     with:
       plugin-repo: ${{ github.repository }}
       plugin-target-branch: ${{ inputs.target-branch }}

--- a/.github/workflows/playground-cleanup.yml
+++ b/.github/workflows/playground-cleanup.yml
@@ -11,6 +11,7 @@ jobs:
   cleanup-preview:
     name: Remove Preview from GitHub Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read       # Required to checkout the repository.
       actions: read        # Required to download the github-pages artifact via actions/download-artifact.

--- a/.github/workflows/playground-cleanup.yml
+++ b/.github/workflows/playground-cleanup.yml
@@ -12,10 +12,10 @@ jobs:
     name: Remove Preview from GitHub Pages
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
-      deployments: read
+      contents: read       # Required to checkout the repository.
+      actions: read        # Required to download the github-pages artifact via actions/download-artifact.
+      pages: write         # Required to redeploy GitHub Pages after removing a preview ZIP.
+      id-token: write      # Required for OIDC token exchange when deploying to Pages.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -4,16 +4,21 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   playground-preview:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.fork == false
-
     permissions:
-      contents: read
-      pull-requests: write
-      pages: write
-      id-token: write
+      contents: read       # Required to checkout the repository.
+      issues: write        # Required for github-script issue/PR comments.
+      actions: write       # Required to delete prior github-pages workflow artifacts.
+      pages: write         # Required to publish GitHub Pages preview builds.
+      id-token: write      # Required for OIDC token exchange when deploying to Pages.
+
+    if: github.event.pull_request.head.repo.fork == false
 
     concurrency:
       group: pages-${{ github.event.pull_request.number }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   playground-preview:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read       # Required to checkout the repository.
       issues: write        # Required for github-script issue/PR comments.

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read       # Required to checkout the repository.
       issues: write        # Required for github-script issue/PR comments.
-      actions: write       # Required to delete prior github-pages workflow artifacts.
+      actions: write       # Required for github.rest.actions.deleteArtifact below.
       pages: write         # Required to publish GitHub Pages preview builds.
       id-token: write      # Required for OIDC token exchange when deploying to Pages.
 

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      contents: read # Required to checkout the repository.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -26,7 +26,7 @@ jobs:
       dist: ${{ steps.workflow.outputs.DIST }}
       package: ${{ steps.workflow.outputs.PACKAGE }}
     permissions:
-      contents: read
+      contents: read # Required to checkout the repository.
 
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
     timeout-minutes: 60
     needs: build
     permissions:
-      contents: read
+      contents: read # Required to checkout the repository.
 
     steps:
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: {} # No GITHUB_TOKEN repo scopes needed; Satis dispatch uses WEBHOOK_TOKEN.
     steps:
 

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -13,8 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    permissions: {} # No GITHUB_TOKEN repo scopes needed; Satis dispatch uses WEBHOOK_TOKEN.
     steps:
 
       - name: Set Package

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: On Push
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.repository == 'newfold-labs/wp-plugin-hostgator' }}
     permissions:
       contents: read       # Required to checkout the repository.

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'newfold-labs/wp-plugin-hostgator' }}
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read       # Required to checkout the repository.
+      issues: write        # Required to create/update PR comments via the Issues API.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -12,10 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to checkout the repository and upload release assets.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write # Required to checkout the repository and upload release assets.
     steps:


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 16 (`add-to-project.yml`, `auto-translate.yml`, `codecoverage-main.yml`, `create-milestone.yml`, `delete-release.yml`, `eslint.yml`, `lint-php.yml`, `lint-yml.yml`, `newfold-prepare-release.yml`, `playground-cleanup.yml`, `playground-preview.yml`, `playwright-matrix.yml`, `playwright-tests.yml`, `satis-webhook.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `54aff4cf` |
| Timeouts commit | `a6745d58` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-asset-on-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `playground-preview.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (replaced prior workflow-wide `permissions: contents: read` with default-deny + job scoping) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-yml.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `create-milestone.yml` (replaced workflow-wide permissions with default-deny + job scoping) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `add-to-project.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| upload-asset-on-release.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: write` [3] |
| lint-php.yml | 1 job was missing a scoped `permissions:` directive | lint-php | `contents: read` [3] |
| lint-yml.yml | 1 job was missing a scoped `permissions:` directive | lint-yml | `contents: read` [3] |
| delete-release.yml | 1 job was missing a scoped `permissions:` directive | delete | `permissions: {}` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| add-to-project.yml | 1 job was missing a scoped `permissions:` directive | add-to-project | `permissions: {}` [3] |
| create-milestone.yml | 1 job was missing an explicit job-level `permissions:` directive (permissions previously inherited from workflow-wide defaults) | create-milestone | `issues: write` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `satis-webhook.yml` :: `webhook`: BEFORE `contents: write` -> AFTER `permissions: {}` -- job does not check out the repo and dispatches via `WEBHOOK_TOKEN`, so default `GITHUB_TOKEN` repo scopes were unnecessary -- [3] |
| 2 | `upload-artifact-on-push.yml` :: `build`: BEFORE `pull-requests: write` -> AFTER `issues: write` -- PR commenting uses `github.rest.issues.*` comment endpoints, which map to `issues` permissions rather than `pull-requests` -- [3] |
| 3 | `playground-preview.yml` :: `playground-preview`: BEFORE `pull-requests: write` -> AFTER `issues: write` (+ added `actions: write`) -- same Issues Comments rationale; deleting workflow artifacts requires `actions: write` -- [3] |
| 4 | `playground-cleanup.yml` :: `cleanup-preview`: BEFORE included `deployments: read` -> AFTER removed -- not required for artifact download + Pages redeploy in this workflow -- [2] |
| 5 | `codecoverage-main.yml` :: workflow defaults: BEFORE workflow-wide `contents: read` -> AFTER top-level `permissions: {}` + job-scoped grants -- avoids granting read to jobs that never checkout/use the GitHub API -- [3] |
| 6 | `create-milestone.yml` :: `create-milestone`: BEFORE workflow-level `contents: read` + `issues: write` -> AFTER job-level `issues: write` only -- no checkout; milestone creation uses REST only -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| upload-asset-on-release.yml | build | `30` | release packaging plus dependency installs should finish well under this; caps runaway spending if a step hangs. |
| upload-artifact-on-push.yml | build | `30` | push/PR build mirrors typical CI compile/install expectations without altering existing behavior. |
| satis-webhook.yml | webhook | `15` | webhook-only job should complete quickly; prevents stuck runners on transient external issues. |
| playground-preview.yml | playground-preview | `45` | build + Pages publish + PR commenting can take longer than lint jobs but should remain bounded. |
| playground-cleanup.yml | cleanup-preview | `30` | artifact download + conditional redeploy should remain comfortably within this window. |
| lint-php.yml | lint-php | `30` | PHPCS over changed files plus Composer setup should not approach this limit in normal conditions. |
| eslint.yml | ESLint | `30` | Node/Composer setup plus ESLint should remain bounded for typical PRs. |
| delete-release.yml | delete | `15` | single external cache purge call should finish quickly or fail fast. |
| codecoverage-main.yml | get-repo-name | `10` | output-only job should be effectively instantaneous aside from runner overhead. |
| codecoverage-main.yml | codecoverage | `90` | reusable coverage workflow runs multi-version PHP tests and can be materially slower than lint workflows. |
| auto-translate.yml | translate | `60` | translation automation may involve installs/API work via reusable workflow; bounded below default unlimited runtime. |
| newfold-prepare-release.yml | prep-release | `60` | release preparation via reusable workflow may involve multiple git/GitHub operations. |
| lint-yml.yml | lint-yml | `15` | checkout + yamllint should complete quickly. |
| create-milestone.yml | create-milestone | `15` | single REST milestone creation should complete quickly. |
| add-to-project.yml | add-to-project | `15` | org project addition via PAT-backed action should be fast. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Caller grants for `uses: newfold-labs/workflows/...` jobs (`codecoverage-main.yml`, `auto-translate.yml`, `newfold-prepare-release.yml`) could not be fully validated against the reusable workflow internals here; confirm the callee still operates with `contents: write` / `pull-requests: write` as intended. |
| 2 | `lint-yml.yml` triggers an `actionlint` YAML-shape warning around `on:` (`pull_request` nested under `push`); this appears pre-existing and unrelated to permissions/timeouts changes—consider fixing separately if you rely on `actionlint` in CI. |
| 3 | If GitHub’s permission checks interpret PR comment updates differently than `issues: write` for your org/repo settings, monitor the next runs of `upload-artifact-on-push.yml` and `playground-preview.yml` after merge. |
| 4 | [REDACTED] |


