### PR TITLE
Fix black logo icon on Login with HostGator button

### DIFF
--- a/inc/Filters.php
+++ b/inc/Filters.php
@@ -103,7 +103,15 @@ final class Filters {
 		);
 		$config['label']        = __( 'Login with HostGator', 'wp-plugin-hostgator' );
 		$config['accent_color'] = Brand::BUTTON_BACKGROUND;
-		$config['icon_svg']     = Helpers::get_svg( 'snappy-head-monotone' );
+
+		// The shared asset hardcodes fill="black", which overrides the module's
+		// `fill: currentColor` CSS and renders the icon black on the button.
+		// Swap to currentColor so it tints with the button's white text color.
+		$config['icon_svg'] = str_replace(
+			'fill="black"',
+			'fill="currentColor"',
+			Helpers::get_svg( 'snappy-head-monotone' )
+		);
 
 		return $config;
 	}


### PR DESCRIPTION
The Snappy icon hardcodes fill="black" in the shared SVG asset, which overrides the SSO module's fill: currentColor CSS and renders the icon black on the button. Swap fill="black" to fill="currentColor" when passing the SVG to the hosting login config so the icon tints white to match the button label. The SVG asset is left unchanged because the Solutions tab integration relies on the original fill="black".

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->