### PR TITLE
Grant contents: write to release asset upload job

### DIFF
--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to upload the built plugin zip as a release asset.
     steps:
 
       - name: Checkout


### PR DESCRIPTION
## Problem
The `Package Plugin` workflow (`upload-asset-on-release.yml`) builds the plugin zip and uploads it to the GitHub release via `actions/upload-release-asset`. That step requires `contents: write`.

The workflow declares **no `permissions:` block**, so it inherits the repository/org **default** `GITHUB_TOKEN` scope. That default is now **read-only**, so the upload fails with:

```
Error: Resource not accessible by integration
```

This is why the **3.1.0** release published but has **no zip asset** attached, while prior releases (3.0.2) succeeded — the default token scope was tightened after the last release.

## Fix
Add a job-level least-privilege `permissions: contents: write` block. This overrides the default token scope for just this job, so the upload works regardless of the repo/org default (no need to loosen the global "Workflow permissions" setting for every workflow).

## Notes
- Scoped to the single job — does not widen any other workflow's token.
- Follow-up worth considering (not in this PR): `actions/upload-release-asset@v1.0.21` is archived and Node-20 deprecated; migrating to `gh release upload` / `softprops/action-gh-release` would also future-proof against the upcoming GitHub App installation token format change.
- The 3.1.0 release will still need its asset attached once this lands (re-run the release's Package Plugin job).