### PR TITLE
fix(PRESS0-4627): reflect purchased eCommerce plan in Commerce page title

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "newfold-labs/wp-module-performance": "^3.7.12",
         "newfold-labs/wp-module-runtime": "^1.2.2",
         "newfold-labs/wp-module-secure-passwords": "^1.1.3",
-        "newfold-labs/wp-module-solutions": "^2.10.0",
+        "newfold-labs/wp-module-solutions": "^2.10.3",
         "newfold-labs/wp-module-sso": "^1.3.0",
         "newfold-labs/wp-module-staging": "^2.7.4",
         "wp-forge/wp-update-handler": "^1.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -2853,16 +2853,16 @@
         },
         {
             "name": "newfold-labs/wp-module-solutions",
-            "version": "2.10.0",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-solutions.git",
-                "reference": "4af6791a50aeabb71c73695597e8f37ed41b5007"
+                "reference": "b616f315a07a28102385a8905293160a49946b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-solutions/zipball/4af6791a50aeabb71c73695597e8f37ed41b5007",
-                "reference": "4af6791a50aeabb71c73695597e8f37ed41b5007",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-solutions/zipball/b616f315a07a28102385a8905293160a49946b66",
+                "reference": "b616f315a07a28102385a8905293160a49946b66",
                 "shasum": ""
             },
             "require": {
@@ -2937,10 +2937,10 @@
             ],
             "description": "A Newfold module that handles integration of WordPress Solutions Addon packages (content creator/ service / ecommerce) for BlueHost & HostGator customers",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-solutions/tree/2.10.0",
+                "source": "https://github.com/newfold-labs/wp-module-solutions/tree/2.10.3",
                 "issues": "https://github.com/newfold-labs/wp-module-solutions/issues"
             },
-            "time": "2026-05-27T15:18:44+00:00"
+            "time": "2026-07-22T22:24:11+00:00"
         },
         {
             "name": "newfold-labs/wp-module-sso",

--- a/src/app/pages/commerce/index.js
+++ b/src/app/pages/commerce/index.js
@@ -15,10 +15,7 @@ const CommercePage = () => {
 				}
 			>
 				<Title as="h1" data-testid="nfd-solutions-commerce-page-title">
-					{ __(
-						'Premium tools available in eCommerce Add-Ons',
-						'wp-plugin-hostgator'
-					) }
+					{ SolutionsPageComponent.getSolutionsPageTitle() }
 				</Title>
 				<Title
 					as="h2"


### PR DESCRIPTION
## Summary

The Commerce page (`#/commerce`, `src/app/pages/commerce/index.js`) rendered a **hardcoded** generic title — *"Premium tools available in eCommerce Add-Ons"* — that never reflected the customer's subscribed eCommerce add-on, even though `window.NewfoldSolutions` carries the active plan.

This renders the shared, plan-aware title from `wp-module-solutions` via `SolutionsPageComponent.getSolutionsPageTitle()` instead. With an active solution the title now reads, e.g.:

- *"Premium tools available in eCommerce Premium Add-On"*
- *"Premium tools available in eCommerce Essentials Add-On"*

and falls back to the generic add-ons title when there is no active solution. Page markup, the `<h1>` `data-testid="nfd-solutions-commerce-page-title"`, and the subtitle are unchanged.

This is the HostGator counterpart of newfold-labs/wp-plugin-bluehost#1328.

## Dependency

Requires the `getSolutionsPageTitle` helper added to / exported from `wp-module-solutions`: newfold-labs/wp-module-solutions#529. Merge + release that module and bump it here via composer before/with this change (otherwise `getSolutionsPageTitle` is undefined at runtime).

## Test plan

- With an active eCommerce Premium/Essentials solution, the Commerce page title includes the purchased add-on name.
- With no active solution, the title falls back to *"Premium tools available in eCommerce Add-Ons"*.

Jira: PRESS0-4627